### PR TITLE
Update default site domain

### DIFF
--- a/euphoria/connection.py
+++ b/euphoria/connection.py
@@ -10,7 +10,7 @@ class Connection:
     receiving packets.
     """
 
-    def __init__(self, limit=0, site="euphoria.io"):
+    def __init__(self, limit=0, site="euphoria.leet.nu"):
         self.site = site
 
         self.socket = None


### PR DESCRIPTION
RIP euphoria.io

In the future, it may be desirable to do some refactoring, since currently the architecture (at least as used by BotBot) doesn't really allow passing an alternate site domain. But there's currently only one heim instance, so